### PR TITLE
Fix email being tappable under bottom app bar

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -408,7 +408,7 @@ class _AnimatedBottomAppBar extends StatelessWidget {
           child: BottomAppBar(
             shape: const CircularNotchedRectangle(),
             notchMargin: 8,
-            child: SizedBox(
+            child: Container(
               height: kToolbarHeight,
               child: Row(
                 mainAxisSize: MainAxisSize.max,


### PR DESCRIPTION
This change fixes a bug where an email was tappable, despite being under the bottom app bar.

