### PR TITLE
Rename AnimationSpeedSetting to SlowMotionSpeedSetting

### DIFF
--- a/lib/model/email_store.dart
+++ b/lib/model/email_store.dart
@@ -170,7 +170,8 @@ class EmailStore with ChangeNotifier {
   String _currentlySelectedInbox = 'Inbox';
   bool _onSearchPage = false;
   ThemeMode _currentTheme = ThemeMode.system;
-  SlowMotionSpeedSetting _currentAnimationSpeed = SlowMotionSpeedSetting.normal;
+  SlowMotionSpeedSetting _currentSlowMotionSpeed =
+      SlowMotionSpeedSetting.normal;
 
   Map<String, Set<Email>> get emails =>
       Map<String, Set<Email>>.unmodifiable(_categories);
@@ -207,7 +208,7 @@ class EmailStore with ChangeNotifier {
   bool get onMailView => _currentlySelectedEmailId > -1;
   bool get onSearchPage => _onSearchPage;
   ThemeMode get themeMode => _currentTheme;
-  SlowMotionSpeedSetting get animationSpeed => _currentAnimationSpeed;
+  SlowMotionSpeedSetting get slowMotionSpeed => _currentSlowMotionSpeed;
 
   bool isEmailStarred(Email email) {
     return _categories['Starred'].contains(email);
@@ -233,8 +234,8 @@ class EmailStore with ChangeNotifier {
     notifyListeners();
   }
 
-  set animationSpeed(SlowMotionSpeedSetting speed) {
-    _currentAnimationSpeed = speed;
-    timeDilation = animationSpeed.value;
+  set slowMotionSpeed(SlowMotionSpeedSetting speed) {
+    _currentSlowMotionSpeed = speed;
+    timeDilation = slowMotionSpeed.value;
   }
 }

--- a/lib/model/email_store.dart
+++ b/lib/model/email_store.dart
@@ -170,7 +170,7 @@ class EmailStore with ChangeNotifier {
   String _currentlySelectedInbox = 'Inbox';
   bool _onSearchPage = false;
   ThemeMode _currentTheme = ThemeMode.system;
-  AnimationSpeedSetting _currentAnimationSpeed = AnimationSpeedSetting.normal;
+  SlowMotionSpeedSetting _currentAnimationSpeed = SlowMotionSpeedSetting.normal;
 
   Map<String, Set<Email>> get emails =>
       Map<String, Set<Email>>.unmodifiable(_categories);
@@ -207,7 +207,7 @@ class EmailStore with ChangeNotifier {
   bool get onMailView => _currentlySelectedEmailId > -1;
   bool get onSearchPage => _onSearchPage;
   ThemeMode get themeMode => _currentTheme;
-  AnimationSpeedSetting get animationSpeed => _currentAnimationSpeed;
+  SlowMotionSpeedSetting get animationSpeed => _currentAnimationSpeed;
 
   bool isEmailStarred(Email email) {
     return _categories['Starred'].contains(email);
@@ -233,7 +233,7 @@ class EmailStore with ChangeNotifier {
     notifyListeners();
   }
 
-  set animationSpeed(AnimationSpeedSetting speed) {
+  set animationSpeed(SlowMotionSpeedSetting speed) {
     _currentAnimationSpeed = speed;
     timeDilation = animationSpeed.value;
   }

--- a/lib/settings_bottom_sheet.dart
+++ b/lib/settings_bottom_sheet.dart
@@ -3,21 +3,21 @@ import 'package:provider/provider.dart';
 
 import 'model/email_store.dart';
 
-enum AnimationSpeedSetting { normal, slow, slower, slowest }
+enum SlowMotionSpeedSetting { normal, slow, slower, slowest }
 
-extension AnimationSpeedSettingExtension on AnimationSpeedSetting {
+extension AnimationSpeedSettingExtension on SlowMotionSpeedSetting {
   double get value {
     switch (this) {
-      case AnimationSpeedSetting.normal:
+      case SlowMotionSpeedSetting.normal:
         return 1.0;
         break;
-      case AnimationSpeedSetting.slow:
+      case SlowMotionSpeedSetting.slow:
         return 5.0;
         break;
-      case AnimationSpeedSetting.slower:
+      case SlowMotionSpeedSetting.slower:
         return 10.0;
         break;
-      case AnimationSpeedSetting.slowest:
+      case SlowMotionSpeedSetting.slowest:
         return 15.0;
         break;
     }
@@ -50,14 +50,14 @@ class SettingsBottomSheet extends StatefulWidget {
 }
 
 class _SettingsBottomSheetState extends State<SettingsBottomSheet> {
-  AnimationSpeedSetting _animationSpeedSetting;
+  SlowMotionSpeedSetting _slowMotionSpeedSetting;
   ThemeMode _themeMode;
 
   @override
   void initState() {
     super.initState();
     _themeMode = Provider.of<EmailStore>(context, listen: false).themeMode;
-    _animationSpeedSetting =
+    _slowMotionSpeedSetting =
         Provider.of<EmailStore>(context, listen: false).animationSpeed;
   }
 
@@ -77,12 +77,12 @@ class _SettingsBottomSheetState extends State<SettingsBottomSheet> {
         Provider.of<EmailStore>(context, listen: false).themeMode = theme;
       }
 
-      void setAnimationSpeed(AnimationSpeedSetting animationSpeed) {
+      void setSlowMotionSpeed(SlowMotionSpeedSetting slowMotionSpeed) {
         state(() {
-          _animationSpeedSetting = animationSpeed;
+          _slowMotionSpeedSetting = slowMotionSpeed;
         });
         Provider.of<EmailStore>(context, listen: false).animationSpeed =
-            animationSpeed;
+            slowMotionSpeed;
       }
 
       return Container(
@@ -106,14 +106,14 @@ class _SettingsBottomSheetState extends State<SettingsBottomSheet> {
                 ],
               ),
               ExpansionTile(
-                title: Text('Animation Speed'),
+                title: Text('Slow Motion'),
                 children: [
-                  for (var animationSpeed in AnimationSpeedSetting.values)
+                  for (var animationSpeed in SlowMotionSpeedSetting.values)
                     RadioListTile(
                       title: Text('${animationSpeed.value.toInt()}x'),
                       value: animationSpeed,
-                      groupValue: _animationSpeedSetting,
-                      onChanged: setAnimationSpeed,
+                      groupValue: _slowMotionSpeedSetting,
+                      onChanged: setSlowMotionSpeed,
                     ),
                 ],
               ),

--- a/lib/settings_bottom_sheet.dart
+++ b/lib/settings_bottom_sheet.dart
@@ -58,7 +58,7 @@ class _SettingsBottomSheetState extends State<SettingsBottomSheet> {
     super.initState();
     _themeMode = Provider.of<EmailStore>(context, listen: false).themeMode;
     _slowMotionSpeedSetting =
-        Provider.of<EmailStore>(context, listen: false).animationSpeed;
+        Provider.of<EmailStore>(context, listen: false).slowMotionSpeed;
   }
 
   @override
@@ -81,7 +81,7 @@ class _SettingsBottomSheetState extends State<SettingsBottomSheet> {
         state(() {
           _slowMotionSpeedSetting = slowMotionSpeed;
         });
-        Provider.of<EmailStore>(context, listen: false).animationSpeed =
+        Provider.of<EmailStore>(context, listen: false).slowMotionSpeed =
             slowMotionSpeed;
       }
 

--- a/lib/settings_bottom_sheet.dart
+++ b/lib/settings_bottom_sheet.dart
@@ -10,16 +10,12 @@ extension AnimationSpeedSettingExtension on SlowMotionSpeedSetting {
     switch (this) {
       case SlowMotionSpeedSetting.normal:
         return 1.0;
-        break;
       case SlowMotionSpeedSetting.slow:
         return 5.0;
-        break;
       case SlowMotionSpeedSetting.slower:
         return 10.0;
-        break;
       case SlowMotionSpeedSetting.slowest:
         return 15.0;
-        break;
     }
     return null;
   }


### PR DESCRIPTION
Rename `Animation Speed` setting to `Slow Motion` in `SettingsBottomSheet`. `Animation Speed` was confusing because `1x, 5x, 10x, 15x` could make people think that the animations are becoming faster when they are actually slowing down.