### PR TITLE
Add dark color shade for splash screen when on dark mode

### DIFF
--- a/android/app/src/main/res/drawable-night/launch_color.xml
+++ b/android/app/src/main/res/drawable-night/launch_color.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="2D2D2D"/>
+    <solid android:color="#2D2D2D"/>
 
 </shape>

--- a/android/app/src/main/res/drawable-night/launch_color.xml
+++ b/android/app/src/main/res/drawable-night/launch_color.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="#2D2D2D"/>
+    <solid android:color="#121212"/>
 
 </shape>

--- a/android/app/src/main/res/drawable-night/launch_color.xml
+++ b/android/app/src/main/res/drawable-night/launch_color.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="2D2D2D"/>
+
+</shape>


### PR DESCRIPTION
This change adds a `drawable-night` directory with a dark `launch_color` drawable for the splash screen background, to better fit dark mode.

![Screenshot_20200905-232400](https://user-images.githubusercontent.com/948037/92348851-2fb81380-f089-11ea-8547-0d70b0220e9c.png)