### PR TITLE
Cleanup left over layout from desktop in inbox.dart

### DIFF
--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -29,26 +29,30 @@ class InboxPage extends StatelessWidget {
                           'Empty in ${model.currentlySelectedInbox.toLowerCase()}',
                         ),
                       )
-                    : ListView(
+                    : SingleChildScrollView(
                         padding: EdgeInsetsDirectional.only(
                           start: horizontalPadding,
                           end: horizontalPadding,
                         ),
-                        children: [
-                          for (int index = 0;
-                              index < model.emails[destination].length;
-                              index++) ...[
-                            MailPreviewCard(
-                              id: index,
-                              email: model.emails[destination].elementAt(index),
-                              onDelete: () =>
-                                  model.deleteEmail(destination, index),
-                              onStar: () => model.starEmail(destination, index),
-                            ),
-                            const SizedBox(height: 4),
+                        child: Column(
+                          children: [
+                            for (int index = 0;
+                                index < model.emails[destination].length;
+                                index++) ...[
+                              MailPreviewCard(
+                                id: index,
+                                email:
+                                    model.emails[destination].elementAt(index),
+                                onDelete: () =>
+                                    model.deleteEmail(destination, index),
+                                onStar: () =>
+                                    model.starEmail(destination, index),
+                              ),
+                              const SizedBox(height: 4),
+                            ],
+                            const SizedBox(height: kToolbarHeight),
                           ],
-                          const SizedBox(height: kToolbarHeight),
-                        ],
+                        ),
                       ),
               ),
             ],

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -33,7 +33,8 @@ class InboxPage extends StatelessWidget {
                     bottom: kToolbarHeight,
                   ),
                   primary: false,
-                  separatorBuilder: (context, index) => SizedBox(height: 4),
+                  separatorBuilder: (context, index) =>
+                      const SizedBox(height: 4),
                   itemBuilder: (context, index) {
                     return MailPreviewCard(
                       id: index,

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -28,9 +28,10 @@ class InboxPage extends StatelessWidget {
               : ListView.separated(
                   itemCount: model.emails[destination].length,
                   padding: EdgeInsetsDirectional.only(
-                      start: horizontalPadding,
-                      end: horizontalPadding,
-                      bottom: kToolbarHeight),
+                    start: horizontalPadding,
+                    end: horizontalPadding,
+                    bottom: kToolbarHeight,
+                  ),
                   separatorBuilder: (context, index) => SizedBox(height: 4),
                   itemBuilder: (context, index) {
                     return MailPreviewCard(

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -19,38 +19,28 @@ class InboxPage extends StatelessWidget {
       builder: (context, model, child) {
         return SafeArea(
           bottom: false,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: model.emails[model.currentlySelectedInbox].isEmpty
-                    ? Center(
-                        child: Text(
-                          'Empty in ${model.currentlySelectedInbox.toLowerCase()}',
-                        ),
-                      )
-                    : ListView.separated(
-                        itemCount: model.emails[destination].length,
-                        padding: EdgeInsetsDirectional.only(
-                          start: horizontalPadding,
-                          end: horizontalPadding,
-                        ),
-                        separatorBuilder: (context, index) =>
-                            SizedBox(height: 4),
-                        shrinkWrap: true,
-                        itemBuilder: (context, index) {
-                          return MailPreviewCard(
-                            id: index,
-                            email: model.emails[destination].elementAt(index),
-                            onDelete: () =>
-                                model.deleteEmail(destination, index),
-                            onStar: () => model.starEmail(destination, index),
-                          );
-                        },
-                      ),
-              ),
-            ],
-          ),
+          child: model.emails[model.currentlySelectedInbox].isEmpty
+              ? Center(
+                  child: Text(
+                    'Empty in ${model.currentlySelectedInbox.toLowerCase()}',
+                  ),
+                )
+              : ListView.separated(
+                  itemCount: model.emails[destination].length,
+                  padding: EdgeInsetsDirectional.only(
+                      start: horizontalPadding,
+                      end: horizontalPadding,
+                      bottom: kToolbarHeight),
+                  separatorBuilder: (context, index) => SizedBox(height: 4),
+                  itemBuilder: (context, index) {
+                    return MailPreviewCard(
+                      id: index,
+                      email: model.emails[destination].elementAt(index),
+                      onDelete: () => model.deleteEmail(destination, index),
+                      onStar: () => model.starEmail(destination, index),
+                    );
+                  },
+                ),
         );
       },
     );

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -32,6 +32,7 @@ class InboxPage extends StatelessWidget {
                     end: horizontalPadding,
                     bottom: kToolbarHeight,
                   ),
+                  primary: false,
                   separatorBuilder: (context, index) => SizedBox(height: 4),
                   itemBuilder: (context, index) {
                     return MailPreviewCard(

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -19,10 +19,10 @@ class InboxPage extends StatelessWidget {
       builder: (context, model, child) {
         return SafeArea(
           bottom: false,
-          child: model.emails[model.currentlySelectedInbox].isEmpty
+          child: model.emails[destination].isEmpty
               ? Center(
                   child: Text(
-                    'Empty in ${model.currentlySelectedInbox.toLowerCase()}',
+                    'Empty in ${destination.toLowerCase()}',
                   ),
                 )
               : ListView.separated(

--- a/lib/inbox.dart
+++ b/lib/inbox.dart
@@ -29,30 +29,24 @@ class InboxPage extends StatelessWidget {
                           'Empty in ${model.currentlySelectedInbox.toLowerCase()}',
                         ),
                       )
-                    : SingleChildScrollView(
+                    : ListView.separated(
+                        itemCount: model.emails[destination].length,
                         padding: EdgeInsetsDirectional.only(
                           start: horizontalPadding,
                           end: horizontalPadding,
                         ),
-                        child: Column(
-                          children: [
-                            for (int index = 0;
-                                index < model.emails[destination].length;
-                                index++) ...[
-                              MailPreviewCard(
-                                id: index,
-                                email:
-                                    model.emails[destination].elementAt(index),
-                                onDelete: () =>
-                                    model.deleteEmail(destination, index),
-                                onStar: () =>
-                                    model.starEmail(destination, index),
-                              ),
-                              const SizedBox(height: 4),
-                            ],
-                            const SizedBox(height: kToolbarHeight),
-                          ],
-                        ),
+                        separatorBuilder: (context, index) =>
+                            SizedBox(height: 4),
+                        shrinkWrap: true,
+                        itemBuilder: (context, index) {
+                          return MailPreviewCard(
+                            id: index,
+                            email: model.emails[destination].elementAt(index),
+                            onDelete: () =>
+                                model.deleteEmail(destination, index),
+                            onStar: () => model.starEmail(destination, index),
+                          );
+                        },
                       ),
               ),
             ],


### PR DESCRIPTION
This change cleans up left over layout code from desktop. Before we needed to use a `Row` that held the `Mailbox` and a search tab on desktop, now we only have a `Mailbox`. Also prefer to use ListView.builder over ListView for lazy building. And disable `primary`, to disable scrolling when content is not sufficient to scroll.

This change also fixes an issue where the inbox was rebuilding twice when going going to a destination with no emails.