### PR TITLE
Enable gapless playback for picture grid assets and use ListView.builder for lazy loading

### DIFF
--- a/lib/mail_card_preview.dart
+++ b/lib/mail_card_preview.dart
@@ -253,18 +253,19 @@ class _PicturePreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       height: 96,
-      child: ListView(
+      child: ListView.builder(
+        itemCount: 4,
         scrollDirection: Axis.horizontal,
-        children: [
-          for (var index = 0; index < 4; index++)
-            Padding(
-              padding: const EdgeInsetsDirectional.only(end: 4),
-              child: Image.asset(
-                'reply/attachments/paris_${index + 1}.jpg',
-                package: 'flutter_gallery_assets',
-              ),
+        itemBuilder: (context, index) {
+          return Padding(
+            padding: const EdgeInsetsDirectional.only(end: 4),
+            child: Image.asset(
+              'reply/attachments/paris_${index + 1}.jpg',
+              gaplessPlayback: true,
+              package: 'flutter_gallery_assets',
             ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/lib/mail_view_page.dart
+++ b/lib/mail_view_page.dart
@@ -149,6 +149,7 @@ class _PictureGrid extends StatelessWidget {
       itemBuilder: (context, index) {
         return Image.asset(
           'reply/attachments/paris_${index + 1}.jpg',
+          gaplessPlayback: true,
           package: 'flutter_gallery_assets',
           fit: BoxFit.fill,
         );


### PR DESCRIPTION
This change enabled `gaplessPlayback` on picture grid assets to reduce white flickering when changing `ImageProvider`. Now pictures only reload when navigating to inbox containing pictures, will not flicker in other situations. Also uses Listview.builder over ListView for lazy loading.