### PR TITLE
Update stack to use clipBehavior parameter over deprecated overflow

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -253,7 +253,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     ).animate(_drawerCurve);
 
     return Stack(
-      overflow: Overflow.visible,
+      clipBehavior: Clip.none,
       key: _bottomDrawerKey,
       children: [
         NotificationListener<ScrollNotification>(


### PR DESCRIPTION
Breaking change: https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea

