### PR TITLE
Depend on stable flutter instead of master

### DIFF
--- a/lib/custom_transition_page.dart
+++ b/lib/custom_transition_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/widgets.dart';
 
-// Prefer to use TransitionBuilderPage once it lands in stable.
-class CustomTransitionPageBuilder extends Page {
+// TODO: Prefer to use TransitionBuilderPage once it lands in stable.
+// https://github.com/material-components/material-components-flutter-motion-codelab/issues/32
+
+class CustomTransitionPage extends Page {
   final Widget screen;
   final ValueKey transitionKey;
 
-  const CustomTransitionPageBuilder(
+  const CustomTransitionPage(
       {@required this.screen, @required this.transitionKey})
       : assert(screen != null),
         assert(transitionKey != null),

--- a/lib/mail_view_router.dart
+++ b/lib/mail_view_router.dart
@@ -28,6 +28,7 @@ class MailViewRouterDelegate extends RouterDelegate<void>
           pages: [
             // TODO: Add Fade through transition between mailbox pages (Motion)
             CustomTransitionPageBuilder(
+              transitionKey: ValueKey(currentlySelectedInbox),
               screen: InboxPage(
                 destination: currentlySelectedInbox,
               ),

--- a/lib/mail_view_router.dart
+++ b/lib/mail_view_router.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:reply/transition_page_builder.dart';
+import 'package:reply/custom_transition_page.dart';
 
 import 'home.dart';
 import 'inbox.dart';
@@ -27,7 +27,7 @@ class MailViewRouterDelegate extends RouterDelegate<void>
           onPopPage: _handlePopPage,
           pages: [
             // TODO: Add Fade through transition between mailbox pages (Motion)
-            CustomTransitionPageBuilder(
+            CustomTransitionPage(
               transitionKey: ValueKey(currentlySelectedInbox),
               screen: InboxPage(
                 destination: currentlySelectedInbox,

--- a/lib/mail_view_router.dart
+++ b/lib/mail_view_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:reply/transition_page_builder.dart';
 
 import 'home.dart';
 import 'inbox.dart';
@@ -26,11 +27,11 @@ class MailViewRouterDelegate extends RouterDelegate<void>
           onPopPage: _handlePopPage,
           pages: [
             // TODO: Add Fade through transition between mailbox pages (Motion)
-            TransitionBuilderPage(
-              pageBuilder: (context, animation, secondaryAnimation) {
-                return InboxPage(destination: currentlySelectedInbox);
-              },
-            ),
+            CustomTransitionPageBuilder(
+              screen: InboxPage(
+                destination: currentlySelectedInbox,
+              ),
+            )
           ],
         );
       },

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:reply/home.dart';
 import 'package:reply/search_page.dart';
+import 'package:reply/transition_page_builder.dart';
 
 import 'model/router_provider.dart';
 
@@ -47,16 +48,10 @@ class ReplyRouterDelegate extends RouterDelegate<ReplyRoutePath>
             onPopPage: _handlePopPage,
             pages: [
               // TODO: Add Shared Z-Axis transition from search icon to search view page (Motion)
-              TransitionBuilderPage(
-                pageBuilder: (context, animation, secondaryAnimation) {
-                  return const HomePage();
-                },
-              ),
+              CustomTransitionPageBuilder(screen: const HomePage()),
               if (routePath is ReplySearchPath)
-                TransitionBuilderPage(
-                  pageBuilder: (context, animation, secondaryAnimation) {
-                    return const SearchPage();
-                  },
+                CustomTransitionPageBuilder(
+                  screen: const SearchPage(),
                 ),
             ],
           );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -48,10 +48,14 @@ class ReplyRouterDelegate extends RouterDelegate<ReplyRoutePath>
             onPopPage: _handlePopPage,
             pages: [
               // TODO: Add Shared Z-Axis transition from search icon to search view page (Motion)
-              CustomTransitionPageBuilder(screen: const HomePage()),
+              const CustomTransitionPageBuilder(
+                transitionKey: ValueKey('Home'),
+                screen: HomePage(),
+              ),
               if (routePath is ReplySearchPath)
-                CustomTransitionPageBuilder(
-                  screen: const SearchPage(),
+                const CustomTransitionPageBuilder(
+                  transitionKey: ValueKey('Search'),
+                  screen: SearchPage(),
                 ),
             ],
           );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:reply/custom_transition_page.dart';
 import 'package:reply/home.dart';
 import 'package:reply/search_page.dart';
-import 'package:reply/transition_page_builder.dart';
 
 import 'model/router_provider.dart';
 
@@ -48,12 +48,12 @@ class ReplyRouterDelegate extends RouterDelegate<ReplyRoutePath>
             onPopPage: _handlePopPage,
             pages: [
               // TODO: Add Shared Z-Axis transition from search icon to search view page (Motion)
-              const CustomTransitionPageBuilder(
+              const CustomTransitionPage(
                 transitionKey: ValueKey('Home'),
                 screen: HomePage(),
               ),
               if (routePath is ReplySearchPath)
-                const CustomTransitionPageBuilder(
+                const CustomTransitionPage(
                   transitionKey: ValueKey('Search'),
                   screen: SearchPage(),
                 ),

--- a/lib/transition_page_builder.dart
+++ b/lib/transition_page_builder.dart
@@ -3,8 +3,13 @@ import 'package:flutter/widgets.dart';
 // Prefer to use TransitionBuilderPage once it lands in stable.
 class CustomTransitionPageBuilder extends Page {
   final Widget screen;
+  final ValueKey transitionKey;
 
-  const CustomTransitionPageBuilder({this.screen});
+  const CustomTransitionPageBuilder(
+      {@required this.screen, @required this.transitionKey})
+      : assert(screen != null),
+        assert(transitionKey != null),
+        super(key: transitionKey);
 
   @override
   Route createRoute(BuildContext context) {

--- a/lib/transition_page_builder.dart
+++ b/lib/transition_page_builder.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+
+// Prefer to use TransitionBuilderPage once it lands in stable.
+class CustomTransitionPageBuilder extends Page {
+  final Widget screen;
+
+  const CustomTransitionPageBuilder({this.screen});
+
+  @override
+  Route createRoute(BuildContext context) {
+    return PageRouteBuilder(
+        settings: this,
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return screen;
+        });
+  }
+}


### PR DESCRIPTION
This change fixes #29 

Navigator 2.0 has been merged into the stable branch of Flutter and landed with version 1.22 this month, but the `TransitionBuilderPage` (used to build pages with custom transitions) has not landed on stable. Issue #29 points out that the build is broken. To reduce build breakages we should depend on stable. This change includes any overhead for the `starter` branch to depend on stable. 

This change implements a `CustomTransitionBuilderPage`, as a temporary solution for `TransitionBuilderPage` not being on stable. 

Code snippets in instructions should be updated to reflect new code. Instructions to be on master branch at the beginning of the codelab can also be removed/replaced with stable branch.