### PR TITLE
Depend on stable flutter instead of master

### DIFF
--- a/lib/mail_view_router.dart
+++ b/lib/mail_view_router.dart
@@ -97,6 +97,8 @@ class MailViewRouterDelegate extends RouterDelegate<void>
   }
 }
 
+// TODO: Prefer to use TransitionBuilderPage once it lands in stable.
+// https://github.com/material-components/material-components-flutter-motion-codelab/issues/32
 class FadeThroughTransitionPageWrapper extends Page {
   FadeThroughTransitionPageWrapper({
     @required this.mailbox,
@@ -112,13 +114,16 @@ class FadeThroughTransitionPageWrapper extends Page {
   Route createRoute(BuildContext context) {
     return PageRouteBuilder(
         settings: this,
-        pageBuilder: (context, animation, secondaryAnimation) {
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return FadeThroughTransition(
             fillColor: Theme.of(context).scaffoldBackgroundColor,
             animation: animation,
             secondaryAnimation: secondaryAnimation,
-            child: mailbox,
+            child: child,
           );
+        },
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return mailbox;
         });
   }
 }

--- a/lib/mail_view_router.dart
+++ b/lib/mail_view_router.dart
@@ -97,27 +97,28 @@ class MailViewRouterDelegate extends RouterDelegate<void>
   }
 }
 
-class FadeThroughTransitionPageWrapper extends TransitionBuilderPage {
+class FadeThroughTransitionPageWrapper extends Page {
   FadeThroughTransitionPageWrapper({
     @required this.mailbox,
     @required this.transitionKey,
   })  : assert(mailbox != null),
         assert(transitionKey != null),
-        super(
-          key: transitionKey,
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            return FadeThroughTransition(
-              fillColor: Theme.of(context).scaffoldBackgroundColor,
-              animation: animation,
-              secondaryAnimation: secondaryAnimation,
-              child: child,
-            );
-          },
-          pageBuilder: (context, animation, secondaryAnimation) {
-            return mailbox;
-          },
-        );
+        super(key: transitionKey);
 
   final Widget mailbox;
   final ValueKey transitionKey;
+
+  @override
+  Route createRoute(BuildContext context) {
+    return PageRouteBuilder(
+        settings: this,
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return FadeThroughTransition(
+            fillColor: Theme.of(context).scaffoldBackgroundColor,
+            animation: animation,
+            secondaryAnimation: secondaryAnimation,
+            child: mailbox,
+          );
+        });
+  }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -111,17 +111,19 @@ class SharedAxisTransitionPageWrapper extends Page {
   @override
   Route createRoute(BuildContext context) {
     return PageRouteBuilder(
+        settings: this,
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
-      return SharedAxisTransition(
-        fillColor: Theme.of(context).cardColor,
-        animation: animation,
-        secondaryAnimation: secondaryAnimation,
-        transitionType: SharedAxisTransitionType.scaled,
-        child: child,
-      );
-    }, pageBuilder: (context, animation, secondaryAnimation) {
-      return screen;
-    });
+          return SharedAxisTransition(
+            fillColor: Theme.of(context).cardColor,
+            animation: animation,
+            secondaryAnimation: secondaryAnimation,
+            transitionType: SharedAxisTransitionType.scaled,
+            child: child,
+          );
+        },
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return screen;
+        });
   }
 }
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -47,14 +47,14 @@ class ReplyRouterDelegate extends RouterDelegate<ReplyRoutePath>
             key: navigatorKey,
             onPopPage: _handlePopPage,
             pages: [
-              SharedAxisTransitionPageWrapper(
+              const SharedAxisTransitionPageWrapper(
                 transitionKey: ValueKey('home'),
-                screen: const HomePage(),
+                screen: HomePage(),
               ),
               if (routePath is ReplySearchPath)
-                SharedAxisTransitionPageWrapper(
+                const SharedAxisTransitionPageWrapper(
                   transitionKey: ValueKey('search'),
-                  screen: const SearchPage(),
+                  screen: SearchPage(),
                 ),
             ],
           );
@@ -97,7 +97,7 @@ class ReplySearchPath extends ReplyRoutePath {
 }
 
 class SharedAxisTransitionPageWrapper extends Page {
-  SharedAxisTransitionPageWrapper(
+  const SharedAxisTransitionPageWrapper(
       {@required this.screen, @required this.transitionKey})
       : assert(screen != null),
         assert(transitionKey != null),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -96,29 +96,30 @@ class ReplySearchPath extends ReplyRoutePath {
   const ReplySearchPath();
 }
 
-class SharedAxisTransitionPageWrapper extends TransitionBuilderPage {
+class SharedAxisTransitionPageWrapper extends Page {
   SharedAxisTransitionPageWrapper(
       {@required this.screen, @required this.transitionKey})
       : assert(screen != null),
         assert(transitionKey != null),
-        super(
-          key: transitionKey,
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            return SharedAxisTransition(
-              fillColor: Theme.of(context).cardColor,
-              animation: animation,
-              secondaryAnimation: secondaryAnimation,
-              transitionType: SharedAxisTransitionType.scaled,
-              child: child,
-            );
-          },
-          pageBuilder: (context, animation, secondaryAnimation) {
-            return screen;
-          },
-        );
+        super(key: transitionKey);
 
   final Widget screen;
   final ValueKey transitionKey;
+
+  @override
+  Route createRoute(BuildContext context) {
+    return PageRouteBuilder(
+        settings: this,
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return SharedAxisTransition(
+            fillColor: Theme.of(context).cardColor,
+            animation: animation,
+            secondaryAnimation: secondaryAnimation,
+            transitionType: SharedAxisTransitionType.scaled,
+            child: screen,
+          );
+        });
+  }
 }
 
 class ReplyRouteInformationParser

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -96,6 +96,8 @@ class ReplySearchPath extends ReplyRoutePath {
   const ReplySearchPath();
 }
 
+// TODO: Prefer to use TransitionBuilderPage once it lands in stable.
+// https://github.com/material-components/material-components-flutter-motion-codelab/issues/32
 class SharedAxisTransitionPageWrapper extends Page {
   const SharedAxisTransitionPageWrapper(
       {@required this.screen, @required this.transitionKey})
@@ -109,16 +111,17 @@ class SharedAxisTransitionPageWrapper extends Page {
   @override
   Route createRoute(BuildContext context) {
     return PageRouteBuilder(
-        settings: this,
-        pageBuilder: (context, animation, secondaryAnimation) {
-          return SharedAxisTransition(
-            fillColor: Theme.of(context).cardColor,
-            animation: animation,
-            secondaryAnimation: secondaryAnimation,
-            transitionType: SharedAxisTransitionType.scaled,
-            child: screen,
-          );
-        });
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      return SharedAxisTransition(
+        fillColor: Theme.of(context).cardColor,
+        animation: animation,
+        secondaryAnimation: secondaryAnimation,
+        transitionType: SharedAxisTransitionType.scaled,
+        child: child,
+      );
+    }, pageBuilder: (context, animation, secondaryAnimation) {
+      return screen;
+    });
   }
 }
 


### PR DESCRIPTION
This change fixes #29 

Navigator 2.0 has been merged into the stable branch of Flutter and landed with version 1.22 this month, but the `TransitionBuilderPage` (used to build pages with custom transitions) has been removed from master (https://github.com/flutter/flutter/pull/66694). Issue #29 points out that the build is broken. To reduce build breakages we should depend on stable. This change includes any overhead for the `starter` branch to depend on stable. 

The main changes are that instead of our SharedAxis and FadeThrough transition page wrappers extending `TransitionBuilderPage`, they now extend `Page` and the implementation has been updated to reflect this.

Code snippets in instructions should be updated to reflect new code. Instructions to be on master branch at the beginning of the codelab can also be removed/replaced with stable branch.