### PR TITLE
Fix minimum sdk to reflect AnimationController signature change

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.8.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
It looks like upgrading to >=2.8.0 is fixing the issue with AnimationController: The named parameter 'vsync' isn't defined. 

See also 
* https://stackoverflow.com/questions/63207206/animationcontroller-the-named-parameter-vsync-isnt-defined
* https://github.com/flutter/flutter/issues/63088